### PR TITLE
Check if content is an array

### DIFF
--- a/helpers/module-helper.js
+++ b/helpers/module-helper.js
@@ -1,5 +1,5 @@
 const findNodes = (content, findFunction) => {
-    if (!content) {
+    if (!content || !Array.isArray(content)) {
         return;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@24hr/rawb-abfirst-analyzer",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "A/B Testing Module Analyzer",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
In Gutenberg, the content may not always be wrapped in a section, so we cannot guarantee that content is always an array.
I've just added a `Array.isArray` check.